### PR TITLE
[FDORA-11] feat: 판매자 주문관리 페이지 항목 갯수 호출 API 구현

### DIFF
--- a/src/main/java/com/farmdora/farmdoraactivity/common/response/SuccessMessage.java
+++ b/src/main/java/com/farmdora/farmdoraactivity/common/response/SuccessMessage.java
@@ -17,7 +17,8 @@ public enum SuccessMessage {
     SEARCH_ORDERSTATUSINFO_SUCCESS("주문 현황 조회에 성공하였습니다."),
     SEARCH_LIKE_SUCCESS("찜 리스트 조회에 성공하였습니다."),
     SEARCH_DELETELIKE_SUCCESS("찜 항목 삭제에 성공하였습니다."),
-    SEARCH_QUESTIONINFO_SUCCESS("내 문의 내역 조회에 성공하였습니다.");
+    SEARCH_QUESTIONINFO_SUCCESS("내 문의 내역 조회에 성공하였습니다."),
+    SEARCH_ORDERMANAGE_SUCCESS("주문 관리 내역 조회에 성공하였습니다.");
 
 
 

--- a/src/main/java/com/farmdora/farmdoraactivity/entity/Broadcast.java
+++ b/src/main/java/com/farmdora/farmdoraactivity/entity/Broadcast.java
@@ -39,4 +39,7 @@ public class Broadcast extends BaseTimeEntity {
 
     @Column(nullable = false)
     private boolean isBlind;
+
+    @Column(nullable = false, length = 50, name= "description")
+    private String desc;
 }

--- a/src/main/java/com/farmdora/farmdoraactivity/seller/controller/OrderManageController.java
+++ b/src/main/java/com/farmdora/farmdoraactivity/seller/controller/OrderManageController.java
@@ -1,0 +1,28 @@
+package com.farmdora.farmdoraactivity.seller.controller;
+
+import com.farmdora.farmdoraactivity.common.response.HttpResponse;
+import com.farmdora.farmdoraactivity.seller.service.OrderManageService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import static com.farmdora.farmdoraactivity.common.response.SuccessMessage.SEARCH_ORDERMANAGE_SUCCESS;
+
+@RestController
+@RequestMapping("/api/my/seller/order")
+@CrossOrigin("http://localhost:5173")
+@RequiredArgsConstructor
+@Slf4j
+public class OrderManageController {
+    private final OrderManageService orderManageService;
+
+    @GetMapping
+    public ResponseEntity<HttpResponse> getOrderManageCount(@RequestParam Integer sellerId) {
+        return ResponseEntity
+                .ok()
+                .body(new HttpResponse(HttpStatus.OK, SEARCH_ORDERMANAGE_SUCCESS.getMessage(),
+                        orderManageService.getAllStatistics(sellerId)));
+    }
+}

--- a/src/main/java/com/farmdora/farmdoraactivity/seller/repository/OrderManageRepository.java
+++ b/src/main/java/com/farmdora/farmdoraactivity/seller/repository/OrderManageRepository.java
@@ -9,11 +9,11 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface OrderManageRepository extends JpaRepository<Order, Integer> {
 
-    @Query("SELECT COUNT(DISTINCT o.id) FROM Order o " +
-            "JOIN o.orderOption oo " +
+    @Query("SELECT COUNT(DISTINCT o.id) FROM OrderOption oo " +
+            "JOIN oo.order o " +
             "JOIN oo.option opt " +
             "JOIN opt.sale s " +
-            "WHERE s.sellerId = :sellerId " +
+            "WHERE s.seller.id = :sellerId " +
             "AND (:statusId IS NULL OR o.status.id = :statusId) ")
     Long countOrdersBySeller(@Param("sellerId") Integer sellerId,
                              @Param("statusId") Short statusId);

--- a/src/main/java/com/farmdora/farmdoraactivity/seller/repository/OrderManageRepository.java
+++ b/src/main/java/com/farmdora/farmdoraactivity/seller/repository/OrderManageRepository.java
@@ -3,13 +3,29 @@ package com.farmdora.farmdoraactivity.seller.repository;
 import com.farmdora.farmdoraactivity.entity.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface OrderManageRepository extends JpaRepository<Order, Integer> {
 
-    @Query("SELECT o.id, s.title, opt.name, o.createdDate, u.name, oo.price, os.name " +
-            "FROM Order o " +
-            "JOIN o.status")
+    @Query("SELECT COUNT(DISTINCT o.id) FROM Order o " +
+            "JOIN o.orderOption oo " +
+            "JOIN oo.option opt " +
+            "JOIN opt.sale s " +
+            "WHERE s.sellerId = :sellerId " +
+            "AND (:statusId IS NULL OR o.status.id = :statusId) ")
+    Long countOrdersBySeller(@Param("sellerId") Integer sellerId,
+                             @Param("statusId") Short statusId);
+
+    @Query("SELECT COUNT(r) FROM Review r " +
+            "JOIN r.sale s " +
+            "WHERE s.seller.id = :sellerId")
+    Long countReviewsBySeller(@Param("sellerId") Integer sellerId);
+
+    @Query("SELECT COUNT(q) FROM Question q " +
+            "JOIN q.sale s " +
+            "WHERE s.seller.id = :sellerId")
+    Long countQuestionsBySeller(@Param("sellerId") Integer sellerId);
 
 }

--- a/src/main/java/com/farmdora/farmdoraactivity/seller/service/OrderManageService.java
+++ b/src/main/java/com/farmdora/farmdoraactivity/seller/service/OrderManageService.java
@@ -1,0 +1,28 @@
+package com.farmdora.farmdoraactivity.seller.service;
+
+import com.farmdora.farmdoraactivity.seller.repository.OrderManageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class OrderManageService {
+    private final OrderManageRepository orderManageRepository;
+
+    public Map<String, Long> getAllStatistics(Integer sellerId) {
+        Map<String, Long> statistics = new HashMap<>();
+        statistics.put("totalOrders", orderManageRepository.countOrdersBySeller(sellerId, null));
+        statistics.put("newOrders", orderManageRepository.countOrdersBySeller(sellerId, (short)1));
+        statistics.put("exchangeOrders", orderManageRepository.countOrdersBySeller(sellerId, (short)6));
+        statistics.put("refundOrders", orderManageRepository.countOrdersBySeller(sellerId, (short)5));
+        statistics.put("cancelOrders", orderManageRepository.countOrdersBySeller(sellerId, (short)4));
+        statistics.put("reviewCount", orderManageRepository.countReviewsBySeller(sellerId));
+        statistics.put("questionCount", orderManageRepository.countQuestionsBySeller(sellerId));
+        return statistics;
+    }
+}


### PR DESCRIPTION
:pushpin: 작업 내용
---
- 주문 관리 페이지 항목 개수 호출 API 구현

<br>
<br>


:bulb: 필수 확인
---
### 응답데이터
``` .json
{
    "status": 200,
    "message": "주문 관리 내역 조회에 성공하였습니다.",
    "data": {
        "questionCount": 49,
        "cancelOrders": 50,
        "reviewCount": 62,
        "refundOrders": 58,
        "totalOrders": 224,
        "newOrders": 24,
        "exchangeOrders": 21
    }
}
```

<br>
<br>


:calendar: 작업 기간
---
2025.04.28 ~ 2025.04.28
<br>
<br>


:camera: 스크린샷 (선택)
---

<br>
<br>


:white_check_mark: 참고 사항 (선택)
---

<br>
<br>